### PR TITLE
[#116] 서비스 소개 스크롤뷰 추가

### DIFF
--- a/KeepGoEat-iOS/KeepGoEat-iOS/MyPage/View/ServiceIntroView.swift
+++ b/KeepGoEat-iOS/KeepGoEat-iOS/MyPage/View/ServiceIntroView.swift
@@ -110,7 +110,6 @@ extension ServiceIntroView {
             $0.width.equalToSuperview()
         }
         backgroundImage.snp.makeConstraints {
-//            $0.top.equalTo(headerView.snp.bottom)
             $0.top.equalToSuperview()
             $0.width.equalToSuperview()
         }

--- a/KeepGoEat-iOS/KeepGoEat-iOS/MyPage/View/ServiceIntroView.swift
+++ b/KeepGoEat-iOS/KeepGoEat-iOS/MyPage/View/ServiceIntroView.swift
@@ -110,7 +110,8 @@ extension ServiceIntroView {
             $0.width.equalToSuperview()
         }
         backgroundImage.snp.makeConstraints {
-            $0.top.equalTo(headerView.snp.bottom)
+//            $0.top.equalTo(headerView.snp.bottom)
+            $0.top.equalToSuperview()
             $0.width.equalToSuperview()
         }
         introLabelView.snp.makeConstraints {
@@ -127,6 +128,7 @@ extension ServiceIntroView {
         openSourceButton.snp.makeConstraints {
             $0.top.equalTo(backgroundImage.snp.bottom).offset(16.adjusted)
             $0.height.equalTo(32.adjusted)
+            $0.bottom.equalToSuperview().offset(-16)
             $0.leading.trailing.equalToSuperview().offset(16.adjusted)
         }
         


### PR DESCRIPTION
서비스 소개 부분 스크롤 안되었던 이슈 수정했습니다

## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 서비스 소개 프레임보다 화면이 더 큰 경우 스크롤 되도록 드디어 수정 완료했습니다

```swift
$0.bottom.equalToSuperview().offset(-16)
```
해당 부분 가장 아래에 있는 컴포넌트에 추가하여 스크롤 가능하도록 했습니다. 
(오랫동안 붙잡고 있던 건데 한번에 해결해서 기분이 너무 좋음..)


## 📌 PR Point!
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 내용


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   iPhone   |
| :-------------: | :----------: |
| 화면종류 | 아이폰이미지 |

![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-03-21 at 11 49 53](https://user-images.githubusercontent.com/109775321/226507223-d17b2131-cb96-47a7-9630-2ad19a6d1c6f.gif)


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #116 
