### PR TITLE
[#118] 탈퇴뷰 직접입력 선택 화면 수정

### DIFF
--- a/KeepGoEat-iOS/KeepGoEat-iOS/MyPage/Withdrawal/View/WithdrawalView.swift
+++ b/KeepGoEat-iOS/KeepGoEat-iOS/MyPage/Withdrawal/View/WithdrawalView.swift
@@ -25,6 +25,7 @@ class WithdrawalView: UIView, UITextViewDelegate {
     private let withdrawalScrollView = UIScrollView().then {
         $0.keyboardDismissMode = .interactive
         $0.contentInsetAdjustmentBehavior = .always
+        $0.isScrollEnabled = false
     }
     
     private let withdrawalTitle = UILabel().then {
@@ -102,7 +103,6 @@ class WithdrawalView: UIView, UITextViewDelegate {
 }
     
 extension WithdrawalView {
-    
     func textViewDidBeginEditing(_ textView: UITextView) {
         if textView == manualInputTextView {
             withdrawalScrollView.scrollRectToVisible(manualInputTextView.frame, animated: true)
@@ -112,6 +112,9 @@ extension WithdrawalView {
             textView.text = nil
             textView.textColor = .gray800
             textView.font = .system5
+        }
+        if manualInputTextView.isSelectable {
+            self.withdrawalScrollView.contentOffset.y += 224
         }
     }
         
@@ -124,7 +127,10 @@ extension WithdrawalView {
             textView.font = .system5
             textView.textColor = .gray400
         }
+            self.withdrawalScrollView.contentOffset.y -= 224
+            self.withdrawalScrollView.isScrollEnabled = false
     }
+
     func textViewDidChange(_ textView: UITextView) {
         if !manualInputMessage.isHidden && !textView.text.isEmpty {
             manualInputMessage.isHidden = true
@@ -158,11 +164,6 @@ extension WithdrawalView {
             manualInputTextView
         )
         
-        withdrawalScrollView.snp.makeConstraints {
-            $0.top.equalTo(withdrawalDescription.snp.bottom)
-            $0.bottom.leading.trailing.equalTo(self.safeAreaLayoutGuide)
-        }
-        
         headerView.snp.makeConstraints {
             $0.top.equalTo(self.safeAreaLayoutGuide)
             $0.horizontalEdges.equalTo(self.safeAreaLayoutGuide)
@@ -184,8 +185,13 @@ extension WithdrawalView {
             $0.leading.equalTo(withdrawalTitle)
         }
         
+        withdrawalScrollView.snp.makeConstraints {
+            $0.top.equalTo(withdrawalDescription.snp.bottom)
+            $0.bottom.leading.trailing.equalTo(self.safeAreaLayoutGuide)
+        }
+        
         stopEatButton.snp.makeConstraints {
-            $0.top.equalTo(withdrawalDescription.snp.bottom).offset(16.adjusted)
+            $0.top.equalToSuperview().offset(16.adjusted)
             $0.leading.equalTo(withdrawalTitle)
         }
         
@@ -219,6 +225,7 @@ extension WithdrawalView {
         manualInputMessage.snp.makeConstraints {
             $0.top.equalTo(manualInputTextView.snp.bottom).offset(8.adjusted)
             $0.leading.equalTo(20.adjusted)
+            $0.bottom.equalToSuperview().offset(-500)
         }
         
         withdrawalConfirmButton.snp.makeConstraints {


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 직접입력 선택 시 화면이 스크롤 되어 직접입력 textView가 올라오도록 수정
<!--
```
작성한 코드가 있다면 여기에 주석을 제거하고 적어주세요!
```
-->


## 📌 PR Point!
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 내용


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   iPhone   |
| :-------------: | :----------: |
| 화면종류 | 아이폰이미지 |

![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-03-22 at 13 26 38](https://user-images.githubusercontent.com/109775321/226802106-5db0f836-2382-49ca-95c4-21b80ba4f1ed.gif)


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #118 
