### PR TITLE
Feat [#128] 문의 임시저장 시 모달 사라지도록 수정

### DIFF
--- a/KeepGoEat-iOS/KeepGoEat-iOS/MyPage/Controller/MyPageViewController.swift
+++ b/KeepGoEat-iOS/KeepGoEat-iOS/MyPage/Controller/MyPageViewController.swift
@@ -123,19 +123,19 @@ extension MyPageViewController: HandleContactButtonDelegate, MFMailComposeViewCo
         // ✅ MFMailComposeResult 가지고 메일 작성 인터페이스가 닫힐때의 결과에 대응할 수있다.
         switch result {
         case .cancelled:
-// ✅ The user canceled the operation.
+            // ✅ The user canceled the operation.
             print("cancelled")
         case .saved:
-// ✅ The email message was saved in the user’s drafts folder.
+            // ✅ The email message was saved in the user’s drafts folder.
             print("saved")
         case .sent:
-// ✅ The email message was queued in the user’s outbox.
+            // ✅ The email message was queued in the user’s outbox.
             print("sent")
         case .failed:
-// ✅ The email message was not saved or queued, possibly due to an error.
+            // ✅ The email message was not saved or queued, possibly due to an error.
             print("failed")
         }
-// ✅ Dismiss the mail compose view controller.
+        // ✅ Dismiss the mail compose view controller.
         controller.dismiss(animated: true, completion: nil)
     }
 }

--- a/KeepGoEat-iOS/KeepGoEat-iOS/MyPage/Controller/MyPageViewController.swift
+++ b/KeepGoEat-iOS/KeepGoEat-iOS/MyPage/Controller/MyPageViewController.swift
@@ -119,6 +119,25 @@ extension MyPageViewController: HandleContactButtonDelegate, MFMailComposeViewCo
               let version = dictionary["CFBundleShortVersionString"] as? String else { return "" }
         return version
     }
+    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+        // ✅ MFMailComposeResult 가지고 메일 작성 인터페이스가 닫힐때의 결과에 대응할 수있다.
+        switch result {
+        case .cancelled:
+// ✅ The user canceled the operation.
+            print("cancelled")
+        case .saved:
+// ✅ The email message was saved in the user’s drafts folder.
+            print("saved")
+        case .sent:
+// ✅ The email message was queued in the user’s outbox.
+            print("sent")
+        case .failed:
+// ✅ The email message was not saved or queued, possibly due to an error.
+            print("failed")
+        }
+// ✅ Dismiss the mail compose view controller.
+        controller.dismiss(animated: true, completion: nil)
+    }
 }
 
 extension MyPageViewController: HandleServiceIntroButtonDelegate {

--- a/KeepGoEat-iOS/KeepGoEat-iOS/MyPage/View/ServiceIntroView.swift
+++ b/KeepGoEat-iOS/KeepGoEat-iOS/MyPage/View/ServiceIntroView.swift
@@ -113,6 +113,7 @@ extension ServiceIntroView {
             $0.top.equalToSuperview()
             $0.width.equalToSuperview()
         }
+        
         introLabelView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.top.equalTo(backgroundImage.snp.top).offset(80.adjusted)


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- [마이페이지] - 문의사항에서 취소- 임시저장 취소를 눌렀는데 모달이 안 사라짐 (스와이프 해야 내려감) -> 해결
- 
```swift
func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
        // ✅ MFMailComposeResult 가지고 메일 작성 인터페이스가 닫힐때의 결과에 대응할 수있다.
        switch result {
        case .cancelled:
// ✅ The user canceled the operation.
            print("cancelled")
        case .saved:
// ✅ The email message was saved in the user’s drafts folder.
            print("saved")
        case .sent:
// ✅ The email message was queued in the user’s outbox.
            print("sent")
        case .failed:
// ✅ The email message was not saved or queued, possibly due to an error.
            print("failed")
        }
// ✅ Dismiss the mail compose view controller.
        controller.dismiss(animated: true, completion: nil)
    }

```


## 📌 PR Point!
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 내용


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   iPhone   |
| :-------------: | :----------: |
| 화면종류 | 아이폰이미지 |

https://user-images.githubusercontent.com/109775321/234766178-d0e111a7-1631-46df-9331-5d439c23a43b.MP4



### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #128 
